### PR TITLE
fix: add linting of .tsx to 'eslint' script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env NODE_ENV=production webpack",
     "build-dev": "webpack",
     "deploy": "npm run build && npx gh-pages -d dist -e online-shop",
-    "eslint": "eslint . --ext .ts",
+    "eslint": "eslint . --ext .ts,.tsx",
     "stylelint": "stylelint ./src/**/*.css",
     "prepare": "husky install",
     "start": "webpack serve",


### PR DESCRIPTION
`npm run eslint` only performed linting of `.ts` files. I forgot to add `.tsx` during initial setup.