### PR TITLE
refactor: apply settings to webpack & stylelint providing better CSS Modules experience

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/stylelintrc.json",
   "extends": ["stylelint-config-recommended", "stylelint-config-tailwindcss"],
-  "ignoreFiles": ["dist", "node_modules"]
+  "ignoreFiles": ["dist", "node_modules"],
+  "rules": {
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        "ignorePseudoClasses": ["global"]
+      }
+    ]
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,8 +79,26 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.css$/,
+        test: /\.module\.css$/,
         exclude: /node_modules/,
+        use: [
+          devMode === "production"
+            ? MiniCSSExtractPlugin.loader
+            : "style-loader",
+          {
+            loader: 'css-loader',
+            options: {
+              modules: {
+                localIdentName: '[local]_[hash:base64:5]',
+              }
+            }
+          },
+          "postcss-loader",
+        ],
+      },
+      {
+        test: /\.css$/,
+        exclude: [/node_modules/, /\.module\.css$/],
         use: [
           devMode === "production"
             ? MiniCSSExtractPlugin.loader


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3116682/209796019-550d3be6-67d8-4267-9b02-d9f4088400d9.png)

Allows to see human-readable CSS classes in Devtools

![image](https://user-images.githubusercontent.com/3116682/209796909-436629b8-5e18-4e5c-ba2f-77d1762b4fdd.png)

Switches off Stylelint warning about unknown ":global" modifier in CSS Modules (required for proper styling of react-slider)